### PR TITLE
Use uniform default maxAttempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Fingerprint.show({
 * __confirmationRequired__ (**Android**): If `false` user confirmation is NOT required after a biometric has been authenticated . Default: `true`. See [docs](https://developer.android.com/training/sign-in/biometric-auth#no-explicit-user-action).
 
 * __maxAttempts__ (**Android**): Maximum number of **biometric failures** allowed **across all modalities
-  in the same prompt** (e.g., fingerprint 3 + face 2 = 5). Defaults to **5** for fingerprints or **3** for face scans.
+  in the same prompt** (e.g., fingerprint 3 + face 2 = 5). Defaults to **5**.
   - If backup is enabled (`disableBackup:false`) and the limit is reached, the plugin cancels the
     biometric prompt and automatically opens the device credential screen (PIN/Pattern/Password).
   - If backup is disabled and the limit is reached, the plugin returns `BIOMETRIC_LOCKED_OUT`.

--- a/src/android/Fingerprint.java
+++ b/src/android/Fingerprint.java
@@ -96,12 +96,6 @@ public class Fingerprint extends CordovaPlugin {
     private JSONArray applyDefaultMaxAttempts(JSONArray args) {
         int defaultAttempts = 5;
         try {
-            PackageManager pm = cordova.getActivity().getPackageManager();
-            boolean hasFingerprint = pm.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT);
-            boolean hasFace = pm.hasSystemFeature("android.hardware.biometrics.face");
-            if (hasFace && !hasFingerprint) {
-                defaultAttempts = 3;
-            }
             if (args == null) {
                 args = new JSONArray();
             }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ export interface FingerprintOptions {
   description?: string;
   fallbackButtonTitle?: string;
   cancelButtonTitle?: string;
-  maxAttempts?: number; // Android: default 5 for fingerprint, 3 for face
+  maxAttempts?: number; // Android: default 5
 }
 
 export interface FingerprintPlugin {

--- a/www/Fingerprint.js
+++ b/www/Fingerprint.js
@@ -6,7 +6,7 @@ var Fingerprint = function() {
 function prepareParams (options) {
   options = options || {};
   if (typeof options.disableBackup === "undefined") options.disableBackup = false;
-  // maxAttempts default handled natively (fingerprint:5, face:3)
+  // maxAttempts default handled natively (5)
 
   // Android only customization
   if (!options.fallbackButtonTitle) options.fallbackButtonTitle = "Use backup";


### PR DESCRIPTION
## Summary
- default Android biometric failure limit to 5 regardless of modality
- clarify maxAttempts default in docs, types and JS wrapper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1307258048323aa63a38a53bedca6